### PR TITLE
Add basic website for Bendy stretch reminder app

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -3,16 +3,19 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bendy</title>
+    <title>Privacy Policy - Bendy</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
     <header>
-        <h1>Bendy, The Stretching App</h1>
+        <h1>Privacy Policy</h1>
     </header>
+    <section>
+        <p>Placeholder for privacy policy.</p>
+    </section>
     <footer>
+        <a href="index.html">Home</a>
         <a href="terms.html">Terms of Use</a>
-        <a href="privacy.html">Privacy Policy</a>
     </footer>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1 @@
+console.log('Bendy website loaded');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,35 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background-color: #ffffff;
+    color: #333333;
+    text-align: center;
+}
+
+header {
+    padding: 100px 20px;
+}
+
+h1 {
+    font-size: 3rem;
+    font-weight: 600;
+    margin: 0;
+    color: #000000;
+}
+
+footer {
+    padding: 40px 20px;
+    background: #f2f2f2;
+    color: #666666;
+}
+
+footer a {
+    margin: 0 10px;
+    color: #666666;
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}

--- a/terms.html
+++ b/terms.html
@@ -3,15 +3,18 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bendy</title>
+    <title>Terms of Use - Bendy</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
     <header>
-        <h1>Bendy, The Stretching App</h1>
+        <h1>Terms of Use</h1>
     </header>
+    <section>
+        <p>Placeholder for terms of use.</p>
+    </section>
     <footer>
-        <a href="terms.html">Terms of Use</a>
+        <a href="index.html">Home</a>
         <a href="privacy.html">Privacy Policy</a>
     </footer>
     <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- Create landing page for Bendy with minimal modern styling and big title
- Add Terms of Use and Privacy Policy pages with shared styles and navigation
- Include simple script initialization and shared stylesheet using neutral color palette

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0169c077083238a9312c4914fc465