### PR TITLE
Add navigation bar and constrain layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="terms.html">Terms of Use</a>
+        <a href="privacy.html">Privacy Policy</a>
+    </nav>
     <header>
         <h1>Bendy, The Stretching App</h1>
     </header>

--- a/privacy.html
+++ b/privacy.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="terms.html">Terms of Use</a>
+        <a href="privacy.html">Privacy Policy</a>
+    </nav>
     <header>
         <h1>Privacy Policy</h1>
     </header>

--- a/style.css
+++ b/style.css
@@ -1,14 +1,31 @@
 body {
-    margin: 0;
+    margin: 0 auto;
     padding: 0;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     background-color: #ffffff;
     color: #333333;
-    text-align: center;
+    max-width: 800px;
 }
 
 header {
-    padding: 100px 20px;
+    padding: 60px 20px;
+    text-align: center;
+}
+
+nav {
+    background: #333333;
+    padding: 10px 20px;
+    text-align: center;
+}
+
+nav a {
+    margin: 0 10px;
+    color: #ffffff;
+    text-decoration: none;
+}
+
+nav a:hover {
+    text-decoration: underline;
 }
 
 h1 {
@@ -22,6 +39,7 @@ footer {
     padding: 40px 20px;
     background: #f2f2f2;
     color: #666666;
+    text-align: center;
 }
 
 footer a {
@@ -32,4 +50,9 @@ footer a {
 
 footer a:hover {
     text-decoration: underline;
+}
+
+section {
+    text-align: left;
+    padding: 20px;
 }

--- a/terms.html
+++ b/terms.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="terms.html">Terms of Use</a>
+        <a href="privacy.html">Privacy Policy</a>
+    </nav>
     <header>
         <h1>Terms of Use</h1>
     </header>


### PR DESCRIPTION
## Summary
- add consistent navigation bar linking all pages
- limit layout width and center header/footer
- left-align privacy policy and terms content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02c76f4d8832382fade06dc11dcd1