### PR TITLE
Align privacy policy styling with terms page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -16,49 +16,39 @@
         <h1>Privacy Policy</h1>
     </header>
     <section>
-        <pre>
-Privacy Policy for Bendy
-
-Last updated: August 15, 2025
-
-Your privacy is important to us. This Privacy Policy explains how Bendy (“we,” “our,” or “us”) collects, uses, and protects information when you use our app.
-
-1. Information We Collect
-	•	Personal Information: Bendy does not require you to create an account, and we do not collect personal information such as your name or email unless you voluntarily provide it (for example, if you contact us for support).
-	•	Usage Data: We may collect anonymous data such as app usage patterns (e.g., which stretches are accessed most) to improve the app. This data does not identify you personally.
-	•	Device Information: The app may automatically collect basic technical information such as device type, operating system, and crash logs to ensure performance and stability.
-
-2. How We Use Information
-	•	To operate, maintain, and improve Bendy.
-	•	To troubleshoot technical issues and improve user experience.
-	•	To respond to support requests if you contact us directly.
-
-3. Data Sharing
-
-We do not sell, rent, or trade your personal information. Data may be shared only in limited circumstances:
-	•	With service providers that help us operate the app (e.g., analytics or crash reporting tools).
-	•	If required by law or legal process.
-
-4. Data Security
-
-We take reasonable measures to protect information from unauthorized access, loss, misuse, or disclosure. However, no system is completely secure.
-
-5. Children’s Privacy
-
-Bendy is not directed to children under 13. We do not knowingly collect personal information from children.
-
-6. Your Choices
-	•	You can disable analytics or tracking through your device settings (where applicable).
-	•	You can delete the app at any time to stop further data collection.
-
-7. Changes to This Policy
-
-We may update this Privacy Policy from time to time. Updates will be posted with a new “Last updated” date.
-
-8. Contact Us
-
-If you have questions about this Privacy Policy, please contact us at: exval.team@gmail.com
-        </pre>
+        <p>Last updated: August 15, 2025</p>
+        <p>Your privacy is important to us. This Privacy Policy explains how Bendy (“we,” “our,” or “us”) collects, uses, and protects information when you use our app.</p>
+        <h2>1. Information We Collect</h2>
+        <ul>
+            <li><strong>Personal Information:</strong> Bendy does not require you to create an account, and we do not collect personal information such as your name or email unless you voluntarily provide it (for example, if you contact us for support).</li>
+            <li><strong>Usage Data:</strong> We may collect anonymous data such as app usage patterns (e.g., which stretches are accessed most) to improve the app. This data does not identify you personally.</li>
+            <li><strong>Device Information:</strong> The app may automatically collect basic technical information such as device type, operating system, and crash logs to ensure performance and stability.</li>
+        </ul>
+        <h2>2. How We Use Information</h2>
+        <ul>
+            <li>To operate, maintain, and improve Bendy.</li>
+            <li>To troubleshoot technical issues and improve user experience.</li>
+            <li>To respond to support requests if you contact us directly.</li>
+        </ul>
+        <h2>3. Data Sharing</h2>
+        <p>We do not sell, rent, or trade your personal information. Data may be shared only in limited circumstances:</p>
+        <ul>
+            <li>With service providers that help us operate the app (e.g., analytics or crash reporting tools).</li>
+            <li>If required by law or legal process.</li>
+        </ul>
+        <h2>4. Data Security</h2>
+        <p>We take reasonable measures to protect information from unauthorized access, loss, misuse, or disclosure. However, no system is completely secure.</p>
+        <h2>5. Children’s Privacy</h2>
+        <p>Bendy is not directed to children under 13. We do not knowingly collect personal information from children.</p>
+        <h2>6. Your Choices</h2>
+        <ul>
+            <li>You can disable analytics or tracking through your device settings (where applicable).</li>
+            <li>You can delete the app at any time to stop further data collection.</li>
+        </ul>
+        <h2>7. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time. Updates will be posted with a new “Last updated” date.</p>
+        <h2>8. Contact Us</h2>
+        <p>If you have questions about this Privacy Policy, please contact us at: <a href="mailto:exval.team@gmail.com">exval.team@gmail.com</a></p>
     </section>
     <footer>
         <a href="index.html">Home</a>


### PR DESCRIPTION
## Summary
- Replace preformatted privacy text with structured paragraphs, headings, and lists to use the same font as the Terms of Use page

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a1257cb3608323bf9ba05fc66d0387